### PR TITLE
Add static landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,258 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Sòmi & Sol — Maison Òliba, Perpignan | Refuges urbains méditerranéens</title>
+<meta name="description" content="Refuges urbains méditerranéens : maisons haut de gamme de 4 à 6 chambres. Projet pilote à Perpignan — luxe discret, design local, hospitalité chaleureuse. Rejoignez la liste d’attente.">
+<link rel="canonical" href="/">
+<meta property="og:title" content="Sòmi & Sol — Maison Òliba, Perpignan">
+<meta property="og:description" content="Refuges urbains méditerranéens : maisons haut de gamme de 4 à 6 chambres. Projet pilote à Perpignan — luxe discret, design local, hospitalité chaleureuse. Rejoignez la liste d’attente.">
+<meta property="og:image" content="images/og.jpg">
+<meta property="og:type" content="website">
+<meta property="og:url" content="">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Sòmi & Sol — Maison Òliba, Perpignan">
+<meta name="twitter:description" content="Refuges urbains méditerranéens : maisons haut de gamme de 4 à 6 chambres. Projet pilote à Perpignan — luxe discret, design local, hospitalité chaleureuse. Rejoignez la liste d’attente.">
+<meta name="twitter:image" content="images/og.jpg">
+<!-- TODO: Replace GA ID or remove tracking for MVP -->
+<!--
+<script async src="https://www.googletagmanager.com/gtag/js?id={{GA_MEASUREMENT_ID}}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '{{GA_MEASUREMENT_ID}}');
+</script>
+-->
+<style>
+:root {
+  --cream: #FAF7F2;
+  --terracotta: #C96B4A;
+  --olive: #6B7A49;
+  --ink: #0F1A1C;
+  --stone: #EAE5DE;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  color: var(--ink);
+  background-color: var(--cream);
+  scroll-behavior: smooth;
+}
+@media (prefers-reduced-motion: reduce) {
+  :root { scroll-behavior: auto; }
+}
+body {margin:0;line-height:1.5;}
+img {max-width:100%;height:auto;display:block;}
+header {position:sticky;top:0;background:var(--cream);border-bottom:1px solid var(--stone);z-index:100;}
+.navbar {max-width:72ch;margin:0 auto;display:flex;justify-content:space-between;align-items:center;padding:0.5rem 1rem;}
+.nav-links {display:flex;gap:1rem;align-items:center;}
+nav a {text-decoration:none;color:var(--ink);padding:0.25rem;}
+nav a:hover,nav a:focus {color:var(--terracotta);}
+.lang {background:none;border:0;color:var(--ink);cursor:pointer;padding:0.25rem;}
+.lang.active {text-decoration:underline;}
+main {max-width:72ch;margin:0 auto;padding:1rem;}
+section {margin-bottom:3rem;}
+.hero {display:grid;gap:1rem;align-items:center;}
+@media(min-width:600px){.hero{grid-template-columns:1fr 1fr;}}
+.hero-media{background:var(--stone);min-height:200px;}
+button, input, select, textarea {font:inherit;}
+button {cursor:pointer;}
+.btn-primary {background:var(--terracotta);color:var(--cream);border:0;padding:0.75rem 1.25rem;border-radius:4px;}
+.btn-primary[disabled] {opacity:0.6;cursor:not-allowed;}
+.btn-link {color:var(--olive);text-decoration:underline;}
+.cards {display:grid;gap:1rem;}
+@media(min-width:600px){.cards{grid-template-columns:repeat(3,1fr);}}
+.card {background:var(--stone);padding:1rem;border-radius:6px;}
+.card h3 {margin-top:0;}
+.map {margin-top:1rem;}
+ul {padding-left:1.25rem;}
+form {display:grid;gap:1rem;max-width:40rem;}
+label {display:block;margin-bottom:0.25rem;}
+input, select {width:100%;padding:0.5rem;border:1px solid var(--stone);border-radius:4px;background:#fff;}
+input:focus, select:focus, button:focus {outline:2px solid var(--olive);outline-offset:2px;}
+.radio-group {display:flex;gap:1rem;}
+.status {margin-top:0.5rem;min-height:1.5rem;}
+footer {background:var(--stone);padding:2rem 1rem;text-align:center;}
+footer a {color:var(--ink);}
+.back-to-top {position:fixed;right:1rem;bottom:1rem;background:var(--terracotta);color:var(--cream);border-radius:50%;width:2.5rem;height:2.5rem;display:flex;align-items:center;justify-content:center;text-decoration:none;box-shadow:0 2px 4px rgba(0,0,0,0.2);} 
+.back-to-top:hover,.back-to-top:focus{background:var(--olive);}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}
+.placeholder-logo{width:80px;height:40px;border:1px solid var(--stone);display:inline-block;margin:0.5rem;}
+</style>
+</head>
+<body id="top">
+<header>
+  <div class="navbar">
+    <div>Sòmi &amp; Sol</div>
+    <nav aria-label="Principale">
+      <div class="nav-links">
+        <a href="#concept" data-en="Concept">Concept</a>
+        <a href="#oliba" data-en="Òliba">Òliba</a>
+        <a href="#perpignan" data-en="Perpignan">Perpignan</a>
+        <a href="#signup" data-en="Join">Rejoindre</a>
+        <div class="lang-switch">
+          <button type="button" class="lang active" data-lang="fr">FR</button>|
+          <button type="button" class="lang" data-lang="en">EN</button>
+        </div>
+      </div>
+    </nav>
+  </div>
+</header>
+<main>
+  <section id="hero" data-testid="hero" class="hero">
+    <div>
+      <h1>Maison Òliba — Perpignan</h1>
+      <p data-en="Mediterranean urban refuge, 4–6 rooms. Discreet luxury, locally rooted design, warm hospitality.">Refuge urbain méditerranéen, 4–6 chambres. Luxe discret, design ancré localement, hospitalité chaleureuse.</p>
+      <p>
+        <a href="#signup" class="btn-primary" data-en="Join the Perpignan waitlist">Rejoindre la liste d’attente Perpignan</a>
+      </p>
+      <p>
+        <a href="https://wa.me/{{WHATSAPP_NUMBER}}" class="btn-link" target="_blank" rel="noopener" data-en="Chat on WhatsApp">Parler sur WhatsApp</a>
+      </p>
+    </div>
+    <div class="hero-media">
+      <img src="images/hero.jpg" alt="Façade méditerranéenne baignée de lumière" loading="lazy" onerror="this.style.display='none';">
+    </div>
+  </section>
+  <section id="concept" data-testid="benefits">
+    <h2 data-en="3 reasons to come">3 raisons de venir</h2>
+    <div class="cards">
+      <article class="card">
+        <h3 data-en="Refined Mediterranean design">Design méditerranéen raffiné</h3>
+        <p data-en="Noble materials, soft light, soothing palette.">Matières nobles, lumière douce, palette apaisante.</p>
+      </article>
+      <article class="card">
+        <h3 data-en="Unique sensory experience">Expérience sensorielle unique</h3>
+        <p data-en="Soft sounds, citrus and fig scents, natural textures.">Sons feutrés, senteurs d’agrumes et de figuier, textures naturelles.</p>
+      </article>
+      <article class="card">
+        <h3 data-en="Discreet & professional hospitality">Hospitalité discrète &amp; professionnelle</h3>
+        <p data-en="Warm welcome, daily care, total freedom.">Accueil chaleureux, attentions quotidiennes, liberté totale.</p>
+      </article>
+    </div>
+  </section>
+  <section id="perpignan" data-testid="perpignan">
+    <h2 data-en="Why Perpignan">Pourquoi Perpignan</h2>
+    <p>Centre historique vivant (patrimoine, terrasses, musées).</p>
+    <p>Carrefour Méditerranée–Pyrénées–Espagne (mer, montagne, Catalogne).</p>
+    <p>Renaissance urbaine (revalorisation, piétonnisation).</p>
+    <div class="map">
+      <img src="images/map-perpignan.jpg" alt="Carte de Perpignan" loading="lazy" onerror="this.style.display='none';">
+    </div>
+  </section>
+  <section id="oliba" data-testid="oliba">
+    <h2 data-en="Maison Òliba (pilot project)">Maison Òliba (projet pilote)</h2>
+    <div class="hero-media" style="margin-bottom:1rem;">
+      <img src="images/oliba-exterior.jpg" alt="Extérieur de la Maison Òliba" loading="lazy" onerror="this.style.display='none';">
+    </div>
+    <p>4–6 chambres, tranquillité, ancrage local, adresse cœur de ville.</p>
+    <ul>
+      <li>Petit déjeuner</li>
+      <li>Conciergerie</li>
+      <li>Bien-être (selon faisabilité)</li>
+      <li>Accès réservé aux hôtes</li>
+    </ul>
+    <section>
+      <p><em>“Pensé pour des voyageurs en quête d’authenticité, de beauté et de calme.”</em></p>
+      <div>
+        <span class="placeholder-logo" aria-hidden="true"></span>
+        <span class="placeholder-logo" aria-hidden="true"></span>
+        <span class="placeholder-logo" aria-hidden="true"></span>
+      </div>
+    </section>
+  </section>
+  <section id="signup" data-testid="signup">
+    <h2 data-en="Join the waitlist — Perpignan">Rejoindre la liste d’attente — Perpignan</h2>
+    <p data-en="Early access, pre-opening offers.">Accès anticipé, offres de pré-ouverture.</p>
+    <form id="waitlist" data-testid="form">
+      <div>
+        <label for="fname" data-en="First name">Prénom</label>
+        <input id="fname" name="fname" type="text" required>
+      </div>
+      <div>
+        <label for="email" data-en="Email">Email</label>
+        <input id="email" name="email" type="email" required>
+      </div>
+      <div>
+        <label for="city" data-en="City">Ville</label>
+        <select id="city" name="city" required>
+          <option value="" disabled selected data-en="Choose...">Choisir...</option>
+          <option value="Paris" data-en="Paris">Paris</option>
+          <option value="Lyon" data-en="Lyon">Lyon</option>
+          <option value="Marseille" data-en="Marseille">Marseille</option>
+          <option value="Autre" data-en="Other">Autre</option>
+        </select>
+      </div>
+      <fieldset>
+        <legend data-en="Interest">Intérêt</legend>
+        <div class="radio-group">
+          <label><input type="radio" name="interest" value="Séjour" required> <span data-en="Stay">Séjour</span></label>
+          <label><input type="radio" name="interest" value="Partenariat"> <span data-en="Partnership">Partenariat</span></label>
+          <label><input type="radio" name="interest" value="Investisseur"> <span data-en="Investor">Investisseur</span></label>
+        </div>
+      </fieldset>
+      <div>
+        <label for="phone" data-en="Phone (WhatsApp)">Téléphone (WhatsApp)</label>
+        <input id="phone" name="phone" type="tel">
+      </div>
+      <div>
+        <label><input type="checkbox" name="consent" required> <span data-en="I accept the privacy policy.">J’accepte la politique de confidentialité.</span></label>
+      </div>
+      <button type="submit" class="btn-primary" data-testid="submit" data-en="Send">Envoyer</button>
+      <div id="form-status" class="status" aria-live="polite"></div>
+    </form>
+    <p><small>Vos données ne seront utilisées que pour vous informer du lancement. Aucune communication non sollicitée.</small></p>
+  </section>
+</main>
+<footer id="footer" data-testid="footer">
+  <p data-en="Sòmi &amp; Sol — Mediterranean urban refuges">Sòmi &amp; Sol — Refuges urbains méditerranéens</p>
+  <p>Email {{CONTACT_EMAIL}} · Instagram {{INSTAGRAM_URL}}</p>
+  <p>© <span id="year"></span> Sòmi &amp; Sol. Tous droits réservés.</p>
+  <p><a href="#">Mentions légales</a> · <a href="#">Politique de confidentialité</a></p>
+</footer>
+<a href="#top" class="back-to-top"><span aria-hidden="true">↑</span><span class="sr-only">Retour en haut</span></a>
+<script>
+const langButtons = document.querySelectorAll('.lang');
+const i18nElements = document.querySelectorAll('[data-en]');
+let currentLang = 'fr';
+i18nElements.forEach(el => { el.dataset.fr = el.textContent.trim(); });
+langButtons.forEach(btn => {
+  btn.addEventListener('click', () => switchLang(btn.dataset.lang));
+});
+function switchLang(lang){
+  currentLang = lang;
+  document.documentElement.lang = lang;
+  langButtons.forEach(b => b.classList.toggle('active', b.dataset.lang === lang));
+  i18nElements.forEach(el => {
+    el.textContent = el.dataset[lang];
+  });
+}
+const form = document.getElementById('waitlist');
+const status = document.getElementById('form-status');
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const submitBtn = form.querySelector('button[type="submit"]');
+  submitBtn.disabled = true;
+  status.textContent = '';
+  const data = new FormData(form);
+  try {
+    const response = await fetch('{{FORMSPREE_URL}}', {
+      method: 'POST',
+      headers: { 'Accept': 'application/json' },
+      body: data
+    });
+    if (response.ok) {
+      status.textContent = currentLang === 'fr' ? 'Merci, nous vous contacterons bientôt.' : "Thank you, we'll be in touch.";
+      form.reset();
+    } else {
+      throw new Error('Network');
+    }
+  } catch (err) {
+    status.textContent = currentLang === 'fr' ? 'Une erreur est survenue. Veuillez réessayer.' : 'Something went wrong. Please try again.';
+  } finally {
+    submitBtn.disabled = false;
+  }
+});
+document.getElementById('year').textContent = new Date().getFullYear();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create mobile-first landing page for Sòmi & Sol with hero, benefits, Perpignan overview, pilot details, and signup form
- add language toggle and Formspree-powered waitlist form

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899f56b6b5483299349c6f461253742